### PR TITLE
Check bare tablename for triggers, like we do with views and indexes

### DIFF
--- a/lib/scenic/adapters/postgres.rb
+++ b/lib/scenic/adapters/postgres.rb
@@ -354,7 +354,7 @@ module Scenic
             create_view view.name, view.definition
           end
 
-          lost_triggers = triggers.select {|t| t.table == view.name }
+          lost_triggers = triggers.select {|t| t.table == view.name.split('.').last }
           lost_triggers.each{|trigger| trigger_reapplier.try_trigger_create  trigger}
         end
       end

--- a/lib/scenic/adapters/postgres/trigger_reapplication.rb
+++ b/lib/scenic/adapters/postgres/trigger_reapplication.rb
@@ -37,9 +37,9 @@ module Scenic
           end
 
           if success
-            say "trigger '#{trigger.name}' on '#{trigger.table}' has been recreated"
+            say "trigger '#{trigger.name}' on '#{trigger.namespace}.#{trigger.table}' has been recreated"
           else
-            say "trigger '#{trigger.name}' on '#{trigger.table}' is no longer valid and has been dropped."
+            say "trigger '#{trigger.name}' on '#{trigger.namespace}.#{trigger.table}' is no longer valid and has been dropped."
           end
         end
 

--- a/lib/scenic/adapters/trigger.rb
+++ b/lib/scenic/adapters/trigger.rb
@@ -1,1 +1,0 @@
-trigger.rb

--- a/lib/scenic/trigger.rb
+++ b/lib/scenic/trigger.rb
@@ -8,20 +8,21 @@ module Scenic
   # @api extension
   class Trigger
 
-  	attr_reader :event, :table, :name, :action, :scope, :timing
+  	attr_reader :event, :namespace, :table, :name, :action, :scope, :timing
 
   	def definition
   	<<-DDL
   	  CREATE TRIGGER #{name}
   	  #{@timing} #{@event}
-  	  ON #{@table}
+  	  ON "#{@namespace}".#{@table}
   	  FOR EACH #{@scope}
   	  #{@action};
   	DDL
   	end
 
-    def initialize(event:, table:, name:, action:, scope:, timing:)
+    def initialize(event:, namespace:, table:, name:, action:, scope:, timing:)
       @event = event
+      @namespace = namespace
       @table = table
       @name  = name
       @action = action


### PR DESCRIPTION
Strip namespaces from triggers when doing a comparison to see if they've been removed after dropping and recreating views as part of a migration. This is functionally the same as with dependent views that need to be recreated.

An earlier change patched a problem caused by returning triggers from outside of the current namespace, but the migration caused from that also re-created the triggers. The issue this PR fixes is the first one for us where a migration caused a dependent table's trigger to be dropped.